### PR TITLE
Remove GetParameter actions from SSM Instance Access Policy

### DIFF
--- a/modules/ssm-instance-access/main.tf
+++ b/modules/ssm-instance-access/main.tf
@@ -13,8 +13,6 @@ resource "aws_iam_policy" "ssm_instance_policy" {
               "ssm:GetDocument",
               "ssm:DescribeDocument",
               "ssm:GetManifest",
-              "ssm:GetParameter",
-              "ssm:GetParameters",
               "ssm:ListAssociations",
               "ssm:ListInstanceAssociations",
               "ssm:PutInventory",


### PR DESCRIPTION
These actions are not required for session manager to work, other parts of Systems Manager may require them. 