### PR TITLE
Extract reusable okta-approvals resources into a helper

### DIFF
--- a/modules/okta-approvals-helper/main.tf
+++ b/modules/okta-approvals-helper/main.tf
@@ -1,0 +1,60 @@
+locals {
+  ssm_prefix                 = var.app
+  defaults = {
+    account_alias = null,
+    group_name = null,
+    role_name = null
+  }
+  resources_with_defaults    = {for k, v in var.resources : k => merge(local.defaults, v)}
+  role_map_no_aliases        = {for k, v in local.resources_with_defaults : k => v.role_name if v.account_alias == null}
+  role_map_with_aliases      = {for k, v in local.resources_with_defaults : k => "[${v.account_alias}] -- ${v.role_name}" if v.account_alias != null}
+  env_vars = {
+    APPLICATION_ID           = var.okta_application_id
+    OKTA_CLIENT_ORGURL       = var.okta_org_url
+    SSM_PREFIX               = local.ssm_prefix
+    ROLE_ASSIGNMENT_STRATEGY = var.role_assignment_strategy
+    GROUP_MAP                = jsonencode({for k, v in local.resources_with_defaults : k => v.group_name if v.group_name != null})
+    ROLE_MAP                 = jsonencode(merge(local.role_map_no_aliases, local.role_map_with_aliases))
+  }
+}
+
+resource "aws_ssm_parameter" "authroles" {
+  name  = "/${local.ssm_prefix}/AUTHROLES"
+  type  = "String"
+  value = jsonencode(var.authroles)
+}
+
+data "aws_iam_policy_document" "lambda_policy" {
+  statement {
+    effect  = "Allow"
+    actions = ["ssm:GetParameter"]
+    resources = [
+      "arn:aws:ssm:${var.region}:${var.account_id}:parameter/${var.app}/*"
+    ]
+  }
+}
+
+resource "aws_iam_role" "sym_execute" {
+  name               = "SymExecute-${var.app}"
+  path               = "/sym/"
+  assume_role_policy = data.aws_iam_policy_document.sym_execute_assume_role.json
+}
+
+data "aws_iam_policy_document" "sym_execute_assume_role" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "sts:AssumeRole",
+    ]
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${var.sym_account_id}:root"]
+    }
+    condition {
+      test = "StringEquals"
+      variable = "sts:ExternalId"
+      values = [ var.external_id ]
+    }
+  }
+}
+

--- a/modules/okta-approvals-helper/outputs.tf
+++ b/modules/okta-approvals-helper/outputs.tf
@@ -1,0 +1,19 @@
+output "lambda_env_vars" {
+  description = "The env vars that the lambda needs to function"
+  value       = local.env_vars
+}
+
+output "lambda_policy" {
+  description = "The additional IAM policy elements the lambda needs to function"
+  value       = data.aws_iam_policy_document.lambda_policy
+}
+
+output "sym_execute_role_name" {
+  description = "The name of the cross-account invocation role"
+  value       = aws_iam_role.sym_execute.name
+}
+
+output "sym_execute_role_arn" {
+  description = "The ARN of the cross-account invocation role"
+  value       = aws_iam_role.sym_execute.arn
+}

--- a/modules/okta-approvals-helper/variables.tf
+++ b/modules/okta-approvals-helper/variables.tf
@@ -39,16 +39,6 @@ variable "role_assignment_strategy" {
   type        = string
 }
 
-variable "s3_bucket" {
-  description = "S3 Bucket with the lambda code"
-  default     = "sym-releases"
-}
-
-variable "s3_key" {
-  description = "S3 Key with the path to the lambda code"
-  default     = "sym-lambda-golang/sym-okta-approvals-golang-latest.zip"
-}
-
 variable "sym_account_id" {
   description = "Account ID for Sym Cross-Account Invocation"
   default     = "803477428605"

--- a/modules/okta-approvals/main.tf
+++ b/modules/okta-approvals/main.tf
@@ -1,21 +1,14 @@
-locals {
-  ssm_prefix                 = var.app
-  defaults = {
-    account_alias = null,
-    group_name = null,
-    role_name = null
-  }
-  resources_with_defaults    = {for k, v in var.resources : k => merge(local.defaults, v)}
-  role_map_no_aliases        = {for k, v in local.resources_with_defaults : k => v.role_name if v.account_alias == null}
-  role_map_with_aliases      = {for k, v in local.resources_with_defaults : k => "[${v.account_alias}] -- ${v.role_name}" if v.account_alias != null}
-  env_vars = {
-    APPLICATION_ID           = var.okta_application_id
-    OKTA_CLIENT_ORGURL       = var.okta_org_url
-    SSM_PREFIX               = local.ssm_prefix
-    ROLE_ASSIGNMENT_STRATEGY = var.role_assignment_strategy
-    GROUP_MAP                = jsonencode({for k, v in local.resources_with_defaults : k => v.group_name if v.group_name != null})
-    ROLE_MAP                 = jsonencode(merge(local.role_map_no_aliases, local.role_map_with_aliases))
-  }
+module "okta_approvals_helper" {
+  source                   = "../okta-approvals-helper"
+  account_id               = var.account_id
+  app                      = var.app
+  authroles                = var.authroles
+  external_id              = var.external_id
+  okta_application_id      = var.okta_application_id
+  okta_org_url             = var.okta_org_url
+  region                   = var.region
+  resources                = var.resources
+  role_assignment_strategy = var.role_assignment_strategy
 }
 
 resource "aws_lambda_function" "sym" {
@@ -28,7 +21,7 @@ resource "aws_lambda_function" "sym" {
   runtime = "go1.x"
 
   environment {
-    variables = local.env_vars
+    variables = module.okta_approvals_helper.lambda_env_vars
   }
 
   role = aws_iam_role.lambda_exec.arn
@@ -63,7 +56,11 @@ resource "aws_iam_policy" "lambda_policy" {
   policy      = data.aws_iam_policy_document.lambda_policy.json
 }
 
+
 data "aws_iam_policy_document" "lambda_policy" {
+
+  source_json = module.okta_approvals_helper.lambda_policy.json
+
   statement {
     effect = "Allow"
     actions = [
@@ -75,46 +72,15 @@ data "aws_iam_policy_document" "lambda_policy" {
       "arn:aws:logs:${var.region}:${var.account_id}:log-group:/aws/lambda/${var.app}*:*"
     ]
   }
-  statement {
-    effect  = "Allow"
-    actions = ["ssm:GetParameter"]
-    resources = [
-      "arn:aws:ssm:${var.region}:${var.account_id}:parameter/${var.app}/*"
-    ]
-  }
-}
-
-resource "aws_iam_role" "sym_execute" {
-  name               = "SymExecute-${var.app}"
-  path               = "/sym/"
-  assume_role_policy = data.aws_iam_policy_document.sym_execute_assume_role.json
-}
-
-data "aws_iam_policy_document" "sym_execute_assume_role" {
-  statement {
-    effect = "Allow"
-    actions = [
-      "sts:AssumeRole",
-    ]
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${var.sym_account_id}:root"]
-    }
-    condition {
-      test = "StringEquals"
-      variable = "sts:ExternalId"
-      values = [ var.external_id ]
-    }
-  }
 }
 
 resource "aws_iam_role_policy_attachment" "sym_execute_policy_attach" {
-  role       = aws_iam_role.sym_execute.name
+  role       = module.okta_approvals_helper.sym_execute_role_name
   policy_arn = aws_iam_policy.sym_execute_policy.arn
 }
 
 resource "aws_iam_policy" "sym_execute_policy" {
-  name        = "SymExecute-${var.app}"
+  name        = module.okta_approvals_helper.sym_execute_role_name
   description = "Sym Cross-Account Invocation for ${var.app}"
   policy      = data.aws_iam_policy_document.sym_execute_policy.json
 }
@@ -129,10 +95,4 @@ data "aws_iam_policy_document" "sym_execute_policy" {
       aws_lambda_function.sym.arn,
     ]
   }
-}
-
-resource "aws_ssm_parameter" "authroles" {
-  name  = "/${local.ssm_prefix}/AUTHROLES"
-  type  = "String"
-  value = jsonencode(var.authroles)
 }

--- a/modules/okta-approvals/outputs.tf
+++ b/modules/okta-approvals/outputs.tf
@@ -5,5 +5,5 @@ output "function_arn" {
 
 output "sym_execute_role_arn" {
   description = "The ARN of the cross-account invocation role"
-  value       = aws_iam_role.sym_execute.arn
+  value       = module.okta_approvals_helper.sym_execute_role_arn
 }


### PR DESCRIPTION
Supports use cases where the lambda itself can't be deployed with our
templates, but we still want to reuse as much of our config as possible.