### PR TITLE
Fix ssm:TerminateSession

### DIFF
--- a/modules/ssm-user-access/main.tf
+++ b/modules/ssm-user-access/main.tf
@@ -51,14 +51,10 @@ data "aws_iam_policy_document" "ssm_user" {
       "ssm:GetConnectionStatus",
       "ssm:GetCommandInvocation",
       "ssm:ListCommands",
-      "ssm:ListCommandInvocations"
+      "ssm:ListCommandInvocations",
+      "ssm:TerminateSession"
     ]
     resources = [ "*" ]
-  }
-  statement {
-    effect = "Allow"
-    actions = [ "ssm:TerminateSession" ]
-    resources = [ "arn:aws:ssm:*:*:session/$${aws:username}-*" ]
   }
 }
 

--- a/modules/ssm-user-access/main.tf
+++ b/modules/ssm-user-access/main.tf
@@ -51,10 +51,19 @@ data "aws_iam_policy_document" "ssm_user" {
       "ssm:GetConnectionStatus",
       "ssm:GetCommandInvocation",
       "ssm:ListCommands",
-      "ssm:ListCommandInvocations",
-      "ssm:TerminateSession"
+      "ssm:ListCommandInvocations"
     ]
     resources = [ "*" ]
+  }
+  statement {
+    effect = "Allow"
+    actions = [ "ssm:TerminateSession" ]
+    resources = [ "*" ]
+    condition {
+      test = "StringLike"
+      variable = "ssm:resourceTag/aws:ssmmessages:session-id"
+      values = [ "$${aws:userid}" ]
+    }
   }
 }
 


### PR DESCRIPTION
Using `aws:username` and `aws:userid` don't seem to work.