### PR TITLE
Regular IAM users need to {aws:username} style for terminatesession, …

### DIFF
--- a/modules/ssm-user-access/main.tf
+++ b/modules/ssm-user-access/main.tf
@@ -65,6 +65,11 @@ data "aws_iam_policy_document" "ssm_user" {
       values = [ "$${aws:userid}" ]
     }
   }
+  statement {
+    effect = "Allow"
+    actions = [ "ssm:TerminateSession" ]
+    resources = [ "arn:aws:ssm:*:*:session/$${aws:username}-*" ]
+  }
 }
 
 resource "aws_iam_policy" "ssm_user_policy" {


### PR DESCRIPTION
…whereas federated users need the new style