### PR TITLE
Remove AWS provider version constraints from modules.

### DIFF
--- a/examples/okta-approvals/main.tf
+++ b/examples/okta-approvals/main.tf
@@ -1,13 +1,8 @@
-terraform {
-  required_version = ">= 0.12.7"
-}
-
 provider "aws" {
-  version = "~> 2.0"
-  region  = var.aws_region
+  region = var.aws_region
 }
 
-data "aws_caller_identity" "current" { }
+data "aws_caller_identity" "current" {}
 
 module "okta_approvals" {
   source                   = "../../modules/okta-approvals"

--- a/examples/ssm-instance-access/main.tf
+++ b/examples/ssm-instance-access/main.tf
@@ -1,16 +1,11 @@
-terraform {
-  required_version = ">= 0.12.7"
-}
-
 provider "aws" {
-  version = "~> 2.0"
-  region  = var.aws_region
+  region = var.aws_region
 }
 
 data "aws_caller_identity" "current" {}
 
 module "ssm_instance_access" {
-  source                = "../../modules/ssm-instance-access"
-  ansible_bucket_name   = "sym-ansible-${data.aws_caller_identity.current.account_id}"
-  policy_name           = var.app
+  source              = "../../modules/ssm-instance-access"
+  ansible_bucket_name = "sym-ansible-${data.aws_caller_identity.current.account_id}"
+  policy_name         = var.app
 }

--- a/examples/ssm-instance-access/versions.tf
+++ b/examples/ssm-instance-access/versions.tf
@@ -1,6 +1,7 @@
 terraform {
   required_providers {
     aws = {
+      source  = "hashicorp/aws"
       version = "~> 3.0"
     }
   }

--- a/examples/ssm-user-access/main.tf
+++ b/examples/ssm-user-access/main.tf
@@ -1,17 +1,12 @@
-terraform {
-  required_version = ">= 0.12.7"
-}
-
 provider "aws" {
-  version = "~> 2.0"
-  region  = var.aws_region
+  region = var.aws_region
 }
 
-data "aws_caller_identity" "current" { }
+data "aws_caller_identity" "current" {}
 
 module "ssm_user_access" {
-  source                = "../../modules/ssm-user-access"
-  ansible_bucket_name   = "sym-ansible-*"
-  policy_name           = var.app
-  instance_tag_options  = var.instance_tag_options
+  source               = "../../modules/ssm-user-access"
+  ansible_bucket_name  = "sym-ansible-*"
+  policy_name          = var.app
+  instance_tag_options = var.instance_tag_options
 }

--- a/examples/ssm-user-access/versions.tf
+++ b/examples/ssm-user-access/versions.tf
@@ -1,6 +1,7 @@
 terraform {
   required_providers {
     aws = {
+      source  = "hashicorp/aws"
       version = "~> 3.0"
     }
   }

--- a/modules/okta-approvals/versions.tf
+++ b/modules/okta-approvals/versions.tf
@@ -1,8 +1,0 @@
-terraform {
-  required_providers {
-    aws = {
-      version = "~> 2.0"
-    }
-  }
-  required_version = ">= 0.12"
-}

--- a/modules/ssm-instance-access/main.tf
+++ b/modules/ssm-instance-access/main.tf
@@ -1,7 +1,7 @@
 resource "aws_iam_policy" "ssm_instance_policy" {
-  name = var.policy_name
+  name        = var.policy_name
   description = "Grants instances SSM access for use with Sym access workflows"
-  policy = <<EOT
+  policy      = <<EOT
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -63,11 +63,11 @@ EOT
 }
 
 module "s3_bucket" {
-  source = "terraform-aws-modules/s3-bucket/aws"
-  version = "v1.9.0"
+  source  = "terraform-aws-modules/s3-bucket/aws"
+  version = "v1.25.0"
 
-  bucket        = var.ansible_bucket_name
-  acl           = "private"
+  bucket = var.ansible_bucket_name
+  acl    = "private"
 
   server_side_encryption_configuration = {
     rule = {

--- a/modules/ssm-instance-access/versions.tf
+++ b/modules/ssm-instance-access/versions.tf
@@ -1,8 +1,0 @@
-terraform {
-  required_providers {
-    aws = {
-      version = "~> 2.0"
-    }
-  }
-  required_version = ">= 0.12"
-}

--- a/modules/ssm-user-access/versions.tf
+++ b/modules/ssm-user-access/versions.tf
@@ -1,8 +1,0 @@
-terraform {
-  required_providers {
-    aws = {
-      version = "~> 2.0"
-    }
-  }
-  required_version = ">= 0.12"
-}


### PR DESCRIPTION
These version constraints should go in the configurations that reference
the modules, when necessary.

Validated that the modules plan with TF13 and TF15.