### PR TITLE
Add minimum version constraint to modules per best practice recommendation.

### DIFF
--- a/modules/okta-approvals/versions.tf
+++ b/modules/okta-approvals/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      version = ">= 2.0"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/ssm-instance-access/versions.tf
+++ b/modules/ssm-instance-access/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.0"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/ssm-user-access/versions.tf
+++ b/modules/ssm-user-access/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.0"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
Don't require a maximum version in the module, but do require a minimum.